### PR TITLE
corrected small error and added explanation

### DIFF
--- a/C1-TensorFlow.qmd
+++ b/C1-TensorFlow.qmd
@@ -338,11 +338,13 @@ microbenchmark::microbenchmark(
 ```{r chunk_chapter3_task_12, eval=TRUE, include=TRUE}
 do_something_TF = function(x = matrix(0.0, 10L, 10L)){
   x = tf$constant(x)  # Remember, this is a local copy!
-  mean_per_row = tf$reduce_mean(x, axis = 0L)
-  result = x - mean_per_row
-  return(result)
+  mean_per_row = tf$reduce_mean(x, axis = 1L)
+  result = tf$transpose(x) - mean_per_row 
+  return(tf$transpose(result)) 
 }
 ```
+
+Short explanation: A 2 dimensional tensor in tensorflow can be seen as an array of arrays. E.g. a 20x30 (rows x columns) matrix is an array which consists of 20 arrays of length 30. If we write result = matrix - vector, tensorflow tries to subtract from every inner array of the matrix (so from every row) the vector. Therefore if the want to substract the first number of mean_per_row from the first column of the matrix, we have to transpose this matrix, do the subtraction and then of course transpose it back to the original dimensions.
 
 ```{r chunk_chapter3_task_13, eval=TRUE, include=TRUE}
 test = matrix(0.0, 100L, 100L)
@@ -1067,4 +1069,3 @@ cat("Original intercept: ", intercept, "\n")
 
 `r unhide()`
 :::
-

--- a/C1-TensorFlow.qmd
+++ b/C1-TensorFlow.qmd
@@ -344,7 +344,7 @@ do_something_TF = function(x = matrix(0.0, 10L, 10L)){
 }
 ```
 
-Short explanation: A 2 dimensional tensor in tensorflow can be seen as an array of arrays. E.g. a 20x30 (rows x columns) matrix is an array which consists of 20 arrays of length 30. If we write result = matrix - vector, tensorflow tries to subtract from every inner array of the matrix (so from every row) the vector. Therefore if the want to substract the first number of mean_per_row from the first column of the matrix, we have to transpose this matrix, do the subtraction and then of course transpose it back to the original dimensions. Alternativly one could do `result = x - tf$reshape(mean_per_row, shape = list(20L,1L))` and then omit the second transpose in the return statement. You could now also try to guess, which one of the two is faster and then check that!
+Short explanation: A 2 dimensional tensor in tensorflow can be seen as an array of arrays. E.g. a 20x30 (rows x columns) matrix is an array which consists of 20 arrays of length 30. If we write result = matrix - vector, tensorflow tries to subtract from every inner array of the matrix (so from every row) the vector. Therefore if the want to substract the first number of mean_per_row from the first column of the matrix, we have to transpose this matrix, do the subtraction and then of course transpose it back to the original dimensions. Alternativly one could transform the vector to an matrix of size 20x1: `result = x - tf$reshape(mean_per_row, shape = list(20L,1L))` and then omit the second transpose in the return statement. You could now also try to guess, which one of the two is faster and then check that!
 
 ```{r chunk_chapter3_task_13, eval=TRUE, include=TRUE}
 test = matrix(0.0, 100L, 100L)

--- a/C1-TensorFlow.qmd
+++ b/C1-TensorFlow.qmd
@@ -344,7 +344,7 @@ do_something_TF = function(x = matrix(0.0, 10L, 10L)){
 }
 ```
 
-Short explanation: A 2 dimensional tensor in tensorflow can be seen as an array of arrays. E.g. a 20x30 (rows x columns) matrix is an array which consists of 20 arrays of length 30. If we write result = matrix - vector, tensorflow tries to subtract from every inner array of the matrix (so from every row) the vector. Therefore if the want to substract the first number of mean_per_row from the first column of the matrix, we have to transpose this matrix, do the subtraction and then of course transpose it back to the original dimensions. Alternativly one could do `result = x - tf$reshape(mean_per_row, shape = list(20L,1L))` and the omnit the second transpose in the return statement. You could now also try to guess, which one of the two is faster and then check that!
+Short explanation: A 2 dimensional tensor in tensorflow can be seen as an array of arrays. E.g. a 20x30 (rows x columns) matrix is an array which consists of 20 arrays of length 30. If we write result = matrix - vector, tensorflow tries to subtract from every inner array of the matrix (so from every row) the vector. Therefore if the want to substract the first number of mean_per_row from the first column of the matrix, we have to transpose this matrix, do the subtraction and then of course transpose it back to the original dimensions. Alternativly one could do `result = x - tf$reshape(mean_per_row, shape = list(20L,1L))` and then omit the second transpose in the return statement. You could now also try to guess, which one of the two is faster and then check that!
 
 ```{r chunk_chapter3_task_13, eval=TRUE, include=TRUE}
 test = matrix(0.0, 100L, 100L)

--- a/C1-TensorFlow.qmd
+++ b/C1-TensorFlow.qmd
@@ -344,7 +344,7 @@ do_something_TF = function(x = matrix(0.0, 10L, 10L)){
 }
 ```
 
-Short explanation: A 2 dimensional tensor in tensorflow can be seen as an array of arrays. E.g. a 20x30 (rows x columns) matrix is an array which consists of 20 arrays of length 30. If we write result = matrix - vector, tensorflow tries to subtract from every inner array of the matrix (so from every row) the vector. Therefore if the want to substract the first number of mean_per_row from the first column of the matrix, we have to transpose this matrix, do the subtraction and then of course transpose it back to the original dimensions.
+Short explanation: A 2 dimensional tensor in tensorflow can be seen as an array of arrays. E.g. a 20x30 (rows x columns) matrix is an array which consists of 20 arrays of length 30. If we write result = matrix - vector, tensorflow tries to subtract from every inner array of the matrix (so from every row) the vector. Therefore if the want to substract the first number of mean_per_row from the first column of the matrix, we have to transpose this matrix, do the subtraction and then of course transpose it back to the original dimensions. Alternativly one could do `result = x - tf$reshape(mean_per_row, shape = list(20L,1L))` and the omnit the second transpose in the return statement. You could now also try to guess, which one of the two is faster and then check that!
 
 ```{r chunk_chapter3_task_13, eval=TRUE, include=TRUE}
 test = matrix(0.0, 100L, 100L)


### PR DESCRIPTION
`mean_per_row = tf$reduce_mean(x, axis = 0L) `
does not correspond to
`mean_per_row = apply(x, 1, mean)`
but
`mean_per_row = tf$reduce_mean(x, axis = 1L)`
does

Also for tf matrices
`result = x - mean_per_row`
does not correspond to the same for R matrices, but 
`tf$transpose(tf$transpose(x) - mean_per_row)`
does

Code:
```
library(tensorflow)
x=matrix(1:100, nrow =10L)
correct_mean_per_row =  apply(x, 1, mean)
wrong_TF = tf$reduce_mean(x, axis = 0L)
correct_TF = tf$reduce_mean(x, axis = 1L)
correct_mean_per_row
wrong_TF
correct_TF

do_something_R = function(x = matrix(0.0, 10L, 10L)){
  mean_per_row = apply(x, 1, mean)
  result = x - mean_per_row
  return(result)
}

do_something_TF_new = function(x = matrix(0.0, 10L, 10L)){
  x = tf$constant(x)  # Remember, this is a local copy!
  mean_per_row = tf$reduce_mean(x, axis = 1L)
  result = tf$transpose(x) - mean_per_row 
  return(tf$transpose(result)) 
}

do_something_TF_old = function(x = matrix(0.0, 10L, 10L)){
  x = tf$constant(x)  # Remember, this is a local copy!
  mean_per_row = tf$reduce_mean(x, axis = 0L)
  result = x - mean_per_row 
  return(result) 
}

x=matrix(1:100, nrow =5L)
do_something_R(x)
do_something_TF_new(x)
do_something_TF_old(x)
```